### PR TITLE
arguments object instead of func args in _send

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-    - "0.8"
     - "0.10"
+    - "4"

--- a/lib/httpmetrics.js
+++ b/lib/httpmetrics.js
@@ -184,7 +184,7 @@ Appender.prototype.appendHttpMetrics = function () {
      * This method is invoked to send headers and body to the socket
      * We will need to monkeypatch this to capture the data size
      */
-    http.OutgoingMessage.prototype._send = function (data, encoding) {
+    http.OutgoingMessage.prototype._send = function (data/*, encoding, callback*/) {
 
         // Note that this initialization is mandatory
         // Headers and data might be already received in the stream before
@@ -200,7 +200,7 @@ Appender.prototype.appendHttpMetrics = function () {
         }
 
         //Invoke the original method
-        backupMethods.OutgoingMessage._send.call(this, data, encoding);
+        backupMethods.OutgoingMessage._send.apply(this, arguments);
     };
 
     http.IncomingMessage.prototype.emit = function (event, chunk) {

--- a/package.json
+++ b/package.json
@@ -1,38 +1,39 @@
 {
   "name": "httpmetrics",
   "description": "HTTP monkey-patching to insert metrics to each http call",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "author": "Rohini Harendra <rohini.raghav@gmail.com>",
   "repository": {
-      "type": "git",
-      "url": "https://github.com/yahoo/httpmetrics.git"
+    "type": "git",
+    "url": "https://github.com/yahoo/httpmetrics.git"
   },
   "bugs": {
-      "url" : "http://github.com/yahoo/httpmetrics/issues"
+    "url": "http://github.com/yahoo/httpmetrics/issues"
   },
   "keywords": [
-    "httpmetrics", "yahoo"
+    "httpmetrics",
+    "yahoo"
   ],
-  "licenses":[
-        {
-            "type" : "BSD",
-            "url" : "https://github.com/yahoo/httpmetrics/blob/master/LICENSE"
-        }
-    ],
-  "engines": { "node": ">=0.6" },
-  "dependencies": {
+  "licenses": [
+    {
+      "type": "BSD",
+      "url": "https://github.com/yahoo/httpmetrics/blob/master/LICENSE"
+    }
+  ],
+  "engines": {
+    "node": ">=0.6"
   },
+  "dependencies": {},
   "devDependencies": {
     "jshint": "~0.9.0",
     "yui-lint": "~0.1.1",
     "istanbul": "~0.1.8",
     "vows": "*",
-    "mockery" : "*"
+    "mockery": "*"
   },
   "main": "./lib/httpmetrics.js",
   "scripts": {
-      "pretest": "jshint --config ./node_modules/yui-lint/jshint.json ./lib/",
-      "test": "istanbul cover --print both vows -- --spec ./tests/*.js"
+    "pretest": "jshint --config ./node_modules/yui-lint/jshint.json ./lib/",
+    "test": "istanbul cover --print both vows -- --spec ./tests/*.js"
   }
 }
-


### PR DESCRIPTION
In node 4.x, the method signature in _send has changed, now taking a
callback at the end. If the callback isn't passed along, the rest of the
HTTP actions happening on that socket cannot proceed.

Instead, just pass the whole arguments object along.
